### PR TITLE
allow to prepare the VMWare image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,5 +40,20 @@
       system = "x86_64-linux";
       user   = "mitchellh";
     };
+
+    # Use this to prepare a new VMWare image.
+    #
+    # $ nix build .#vmwareImage -L
+    # $ open ./result/*.vmdk
+    #
+    packages.aarch64-linux = {
+      vmwareImage =
+        self.nixosConfigurations.vm-aarch64.config.system.build.vmwareImage;
+    };
+
+    packages.x86_64-linux = {
+      vmwareImage =
+        self.nixosConfigurations.vm-intel.config.system.build.vmwareImage;
+    };
   };
 }

--- a/hardware/vm-intel.nix
+++ b/hardware/vm-intel.nix
@@ -4,23 +4,13 @@
 { config, lib, pkgs, modulesPath, ... }:
 
 {
-  imports = [ ];
+  imports = [ "${modulesPath}/virtualisation/vmware-image.nix" ];
 
   boot.initrd.availableKernelModules = [
     "ata_piix" "mptspi" "uhci_hcd" "ehci_pci" "sd_mod" "sr_mod" ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ ];
   boot.extraModulePackages = [ ];
-
-  fileSystems."/" =
-    { device = "/dev/disk/by-label/nixos";
-      fsType = "ext4";
-    };
-
-  fileSystems."/boot" =
-    { device = "/dev/disk/by-label/boot";
-      fsType = "vfat";
-    };
 
   swapDevices = [ ];
 


### PR DESCRIPTION
This is more of a showcase of a feature which I really like with NixOS.

If the CI or another machine has Nix installed, it's possible to
generate a new VMDK directly from the NixOS configuration. Building and
copying the VMDK would replace almost all the bootstrap steps from the
video. A similar technique is also possible to generate AMIs and other
system images from the same config.

I wasn't able to test this unfortunately because I don't have VMWare
installed. You might have to set a password to the user using the NixOS
config as well in order to be able to login.
