### PR TITLE
add GitHub Actions

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,24 @@
+name: Nix
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v16
+      # TODO: add a binary cache
+      # - uses: cachix/cachix-action@v10
+      #   with:
+      #     name: YOURCACHE
+      #     authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix flake check
+        # Pre-build the system configuration
+      - run: nix build .#nixosConfigurations.vm-intel


### PR DESCRIPTION
Build the Linux system to make sure it's working all the time.

If a [Cachix](https://cachix.org) cache is added on top, the CI can then
push the build results, and the clients can download binary artefacts
instead of re-building them.