### PR TITLE
Updated to the latest ubuntu

### DIFF
--- a/iso/Dockerfile
+++ b/iso/Dockerfile
@@ -1,7 +1,7 @@
 # Thanks to https://github.com/TobiasBales/nixos-m1-arm-builder/ for
 # the original source that this is based on.
 
-FROM ubuntu:21.10
+FROM ubuntu:22.04
 
 # install dependencies
 RUN apt update -y


### PR DESCRIPTION
Was getting

 ```
=> ERROR [ 2/12] RUN apt update -y                                                                                                                                                                        3.3s
------
 > [ 2/12] RUN apt update -y:
#5 0.264
#5 0.264 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
#5 0.264
#5 1.092 Ign:1 http://ports.ubuntu.com/ubuntu-ports impish InRelease
#5 1.401 Ign:2 http://ports.ubuntu.com/ubuntu-ports impish-updates InRelease
#5 1.709 Ign:3 http://ports.ubuntu.com/ubuntu-ports impish-backports InRelease
#5 2.017 Ign:4 http://ports.ubuntu.com/ubuntu-ports impish-security InRelease
#5 2.322 Err:5 http://ports.ubuntu.com/ubuntu-ports impish Release
#5 2.322   404  Not Found [IP: 185.125.190.39 80]
#5 2.632 Err:6 http://ports.ubuntu.com/ubuntu-ports impish-updates Release
#5 2.632   404  Not Found [IP: 185.125.190.39 80]
#5 2.940 Err:7 http://ports.ubuntu.com/ubuntu-ports impish-backports Release
#5 2.940   404  Not Found [IP: 185.125.190.39 80]
#5 3.245 Err:8 http://ports.ubuntu.com/ubuntu-ports impish-security Release
#5 3.245   404  Not Found [IP: 185.125.190.39 80]
#5 3.246 Reading package lists...
#5 3.252 E: The repository 'http://ports.ubuntu.com/ubuntu-ports impish Release' does not have a Release file.
#5 3.252 E: The repository 'http://ports.ubuntu.com/ubuntu-ports impish-updates Release' does not have a Release file.
#5 3.252 E: The repository 'http://ports.ubuntu.com/ubuntu-ports impish-backports Release' does not have a Release file.
#5 3.252 E: The repository 'http://ports.ubuntu.com/ubuntu-ports impish-security Release' does not have a Release file.
------
executor failed running [/bin/sh -c apt update -y]: exit code: 100
```

According to https://fridge.ubuntu.com/2022/07/19/ubuntu-21-10-impish-indri-end-of-life-reached-on-july-14-2022/ this has reached EOL and the package repositories need to point to old-releases.ubuntu.com. So I just updated to the latest Ubuntu instead.