### PR TITLE
hardware: add nvme kernel module for vm-intel

### DIFF
--- a/hardware/vm-intel.nix
+++ b/hardware/vm-intel.nix
@@ -7,7 +7,7 @@
   imports = [ ];
 
   boot.initrd.availableKernelModules = [
-    "ata_piix" "mptspi" "uhci_hcd" "ehci_pci" "sd_mod" "sr_mod" ];
+    "ata_piix" "mptspi" "uhci_hcd" "ehci_pci" "sd_mod" "sr_mod" "nvme" ];
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ ];
   boot.extraModulePackages = [ ];


### PR DESCRIPTION
Without this vm/bootstrap step will fail if we run the installation on nvme block device.