### PR TITLE
Don't reboot if nixos-install fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,7 @@ vm/bootstrap0:
 			services.openssh.permitRootLogin = \"yes\";\n \
 			users.users.root.initialPassword = \"root\";\n \
 		' /mnt/etc/nixos/configuration.nix; \
-		nixos-install --no-root-passwd; \
-		reboot; \
+		nixos-install --no-root-passwd && reboot; \
 	"
 
 # after bootstrap0, run this to finalize. After this, do everything else


### PR DESCRIPTION
If installation fails for whatever reason (currently boot device config misconfigured), the VM currently reboots. This results in loss of state and it makes it harder to debug.