### PR TITLE
fixed an issue during bootstrap0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ vm/bootstrap0:
 		mount /dev/disk/by-label/boot /mnt/boot; \
 		nixos-generate-config --root /mnt; \
 		sed --in-place '/system\.stateVersion = .*/a \
-			nix.package = pkgs.nixUnstable;\n \
+			nix.package = pkgs.nixVersions.latest;\n \
 			nix.extraOptions = \"experimental-features = nix-command flakes\";\n \
 			nix.settings.substituters = [\"https://mitchellh-nixos-config.cachix.org\"];\n \
 			nix.settings.trusted-public-keys = [\"mitchellh-nixos-config.cachix.org-1:bjEbXJyLrL1HZZHBbO4QALnI5faYZppzkU4D2s0G8RQ=\"];\n \

--- a/machines/wsl.nix
+++ b/machines/wsl.nix
@@ -9,7 +9,7 @@
   };
 
   nix = {
-    package = pkgs.nixUnstable;
+    package = pkgs.nixVersions.latest;
     extraOptions = ''
       experimental-features = nix-command flakes
       keep-outputs = true


### PR DESCRIPTION
pkgs.nixUnstable seems deprecated, so use pkgs.nixVersions.latest instead.

otherwise the following error occurs. https://github.com/mitchellh/nixos-config/issues/40
```
     1574|         || pred here (elemAt values 1) (head values) then
     1575|           head values
         |           ^
     1576|         else

   … while evaluating the attribute 'value'

     at /nix/var/nix/profiles/per-user/root/channels/nixos/lib/modules.nix:809:9:

      808|     in warnDeprecation opt //
      809|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
         |         ^
      810|         inherit (res.defsFinal') highestPrio;

   (stack trace truncated; use '--show-trace' to show the full trace)

   error: nixVersions.unstable has been removed. For bleeding edge (Nix master, roughly weekly updated) use nixVersions.git, otherwise use nixVersions.latest.
```