### PR TITLE
pkgs.nixUnstable is deprecated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ vm/bootstrap0:
 		mount /dev/disk/by-label/boot /mnt/boot; \
 		nixos-generate-config --root /mnt; \
 		sed --in-place '/system\.stateVersion = .*/a \
-			nix.package = pkgs.nixUnstable;\n \
+			nix.package = pkgs.nixVersions.git;\n \
 			nix.extraOptions = \"experimental-features = nix-command flakes\";\n \
 			nix.binaryCaches = [\"https://mitchellh-nixos-config.cachix.org\"];\n \
 			nix.binaryCachePublicKeys = [\"mitchellh-nixos-config.cachix.org-1:bjEbXJyLrL1HZZHBbO4QALnI5faYZppzkU4D2s0G8RQ=\"];\n \


### PR DESCRIPTION
`pkgs.nixUnstable` is deprecated https://github.com/NixOS/nixpkgs/issues/323711 and `pkgs.nixVersions.git` should be used instead