### PR TITLE
Attribute name updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ vm/bootstrap0:
 		mount /dev/disk/by-label/boot /mnt/boot; \
 		nixos-generate-config --root /mnt; \
 		sed --in-place '/system\.stateVersion = .*/a \
-			nix.package = pkgs.nixUnstable;\n \
+			nix.package = pkgs.nixVersions.git;\n \
 			nix.extraOptions = \"experimental-features = nix-command flakes\";\n \
 			nix.settings.substituters = [\"https://mitchellh-nixos-config.cachix.org\"];\n \
 			nix.settings.trusted-public-keys = [\"mitchellh-nixos-config.cachix.org-1:bjEbXJyLrL1HZZHBbO4QALnI5faYZppzkU4D2s0G8RQ=\"];\n \

--- a/modules/specialization/i3.nix
+++ b/modules/specialization/i3.nix
@@ -9,6 +9,7 @@
       config.common.default = "*";
     };
 
+    services.displayManager.defaultSession = "none+i3";
     services.xserver = {
       enable = true;
       xkb.layout = "us";
@@ -20,7 +21,6 @@
       };
 
       displayManager = {
-        defaultSession = "none+i3";
         lightdm.enable = true;
 
         # AARCH64: For now, on Apple Silicon, we must manually set the


### PR DESCRIPTION
Attributes renamed upstream cause this error:
```
error: nixUnstable has been removed. For bleeding edge (Nix master, roughly weekly updated) use nixVersions.git, otherwise use nixVersions.latest.
```
and this warning
```
evaluation warning: The option `services.xserver.displayManager.defaultSession' defined in `/nix/store/28m33imlz96xvy4hyx13jpskif762149-source/modules/specialization/i3.nix' has been renamed to `services.displayManager.defaultSession'.
```
Applied and tested both of these trivial fixes