### PR TITLE
Fix

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,12 @@
+name: Flake
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - run: |
+          nix flake check .

--- a/flake.nix
+++ b/flake.nix
@@ -87,19 +87,29 @@
       inputs.jujutsu.overlays.default
       inputs.zig.overlays.default
 
-      (final: prev: rec {
-        # gh CLI on stable has bugs.
-        gh = inputs.nixpkgs-unstable.legacyPackages.${prev.system}.gh;
+      (final: prev:
+        let
+          # We need to create a new nixpkgs instance from the unstable input
+          # so that we can apply configuration to it, such as allowing unfree
+          # packages.
+          nixpkgs-unstable-configured = import inputs.nixpkgs-unstable {
+            system = prev.system;
+            config.allowUnfree = true;
+          };
+        in
+        rec {
+          # gh CLI on stable has bugs.
+          gh = nixpkgs-unstable-configured.gh;
 
-        # Want the latest version of these
-        claude-code = inputs.nixpkgs-unstable.legacyPackages.${prev.system}.claude-code;
-        nushell = inputs.nixpkgs-unstable.legacyPackages.${prev.system}.nushell;
+          # Want the latest version of these
+          claude-code = nixpkgs-unstable-configured.claude-code;
+          nushell = nixpkgs-unstable-configured.nushell;
 
-        ibus = ibus_stable;
-        ibus_stable = inputs.nixpkgs.legacyPackages.${prev.system}.ibus;
-        ibus_1_5_29 = inputs.nixpkgs-old-ibus.legacyPackages.${prev.system}.ibus;
-        ibus_1_5_31 = inputs.nixpkgs-unstable.legacyPackages.${prev.system}.ibus;
-      })
+          ibus = ibus_stable;
+          ibus_stable = inputs.nixpkgs.legacyPackages.${prev.system}.ibus;
+          ibus_1_5_29 = inputs.nixpkgs-old-ibus.legacyPackages.${prev.system}.ibus;
+          ibus_1_5_31 = nixpkgs-unstable-configured.ibus;
+        })
     ];
 
     mkSystem = import ./lib/mksystem.nix {

--- a/machines/wsl.nix
+++ b/machines/wsl.nix
@@ -9,7 +9,7 @@
   };
 
   nix = {
-    package = pkgs.nixUnstable;
+    package = pkgs.nixVersions.latest;
     extraOptions = ''
       experimental-features = nix-command flakes
       keep-outputs = true


### PR DESCRIPTION
fixes:  error: nixUnstable has been removed. For bleeding edge (Nix master, roughly weekly updated) use nixVersions.git, otherwise use nixVersions.latest.